### PR TITLE
Remove HTML escaping warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
 <br>
 
 `boilerplate` is a minimal compile-time Rust text template engine.
-`boilerplate`'s HTML escaping has not been scrutinized, and should not be used
-in production environments with untrusted input.
 
 ## Quick Start
 


### PR DESCRIPTION
I've read a few articles on HTML escaping, and all test cases are covered, so I believe it's being done correctly. Fixes #16.