### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+[1.2.1](https://github.com/casey/boilerplate/releases/tag/1.2.1) - 2026-06-02
+-----------------------------------------------------------------------------
+
+- Bump Rust edition to 2024 ([#72](https://github.com/casey/filepack/pull/72) by [casey](https://github.com/casey))
+
 [1.2.0](https://github.com/casey/boilerplate/releases/tag/1.2.0) - 2026-05-31
 -----------------------------------------------------------------------------
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "boilerplate"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "boilerplate-macros",
@@ -295,9 +295,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "matchit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boilerplate"
-version = "1.2.0"
+version = "1.2.1"
 description = "Minimal compile-time Rust template engine"
 authors.workspace = true
 categories.workspace = true


### PR DESCRIPTION
- Bump version: 1.2.0 → 1.2.1
- Update changelog
- Update changelog contributor credits
- Update dependencies